### PR TITLE
wsjtz: Add wsjt-z mod

### DIFF
--- a/bucket/wsjtz.json
+++ b/bucket/wsjtz.json
@@ -1,0 +1,37 @@
+{
+    "version": "2.7.0-1.48",
+    "description": "WSJT-Z is a modified version of the WSJT-X software by Joe Taylor K1JT (https://sourceforge.net/projects/wsjt/).",
+    "homepage": "https://sourceforge.net/projects/wsjt-z/",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/wsjt-z/Packages/wsjtz-2.7.0-1.48-win64.exe#/dl.7z",
+            "hash": "sha1:a6ffd92be829a38328503df89ddfcca3f70d7723"
+        },
+        "32bit": {
+            "url": "https://downloads.sourceforge.net/project/wsjt-z/Packages/wsjtz-2.7.0-1.48-win32.exe#/dl.7z",
+            "hash": "sha1:e4ecb1dde7204c40587127d5867ede565bdbc526"
+        }
+    },
+    "shortcuts": [
+        [
+            "bin\\wsjtx.exe",
+            "WSJT-Z"
+        ]
+    ],
+    "checkver": {
+        "url": "https://sourceforge.net/projects/wsjt-z/files/Packages/",
+        "regex": "<tr title=\"wsjtz-([\\d.]+)-([\\d.]+)-win(32|64).exe",
+        "replace": "${1}-${2}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/wsjt-z/Packages/wsjtz-$match1-$match2-win64.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/wsjt-z/Packages/wsjtz-$match1-$match2-win32.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
this mod version support fully automatical QSO.

pros
- mod makes benefit to disabled people such as blind
- when you want to make large qso during field events/POTA/SOTA/..

cons
- many hams don't like fully auto QSO bot
- some behaviors are buggy. you still need monitoring

personally, I perfer/suggest to use `wsjtx-improved`. this manifest is just made for maintaining.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
