### PR TITLE
Bump wsjt-x improved versions

### DIFF
--- a/bucket/wsjtx-improved-al.json
+++ b/bucket/wsjtx-improved-al.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.7.1-250106-RC8",
+    "version": "2.8.0-250314",
     "description": "wsjt-x_improved is an enhanced version (\"the DG2YCB edition\") of the excellent WSJT-X software by Joe Taylor K1JT, Steve Franke K9AN, Bill Somerville G4WJS, me and others (https://sourceforge.net/projects/wsjt/).",
     "homepage": "https://sourceforge.net/projects/wsjt-x-improved/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.7.1/wsjtx-2.7.1-devel-win64_improved_AL_PLUS_250106-RC8.exe#/dl.7z",
-            "hash": "sha1:10e2a00e67770465c164890a3a3d936632dce370"
+            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.8.0/wsjtx-2.8.0-win64_improved_AL_PLUS_250314.exe#/dl.7z",
+            "hash": "sha1:8094f2ca3bca5e0c6e1dbc6df5a7e4e87f3d281b"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.7.1/Windows%2032-bit/wsjtx-2.7.1-devel-win32_improved_AL_PLUS_250106-RC8.exe#/dl.7z",
-            "hash": "sha1:bbf536c4783081a8007c019e3c0569e47813b73c"
+            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.8.0/Windows%2032-bit/wsjtx-2.8.0-win32_improved_AL_PLUS_250314.exe#/dl.7z",
+            "hash": "sha1:849e460f735e0191df8a940aace9562c1cc28468"
         }
     },
     "shortcuts": [

--- a/bucket/wsjtx-improved-al.json
+++ b/bucket/wsjtx-improved-al.json
@@ -20,8 +20,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/README.txt",
-        "regex": "WSJT-X_IMPROVED ([\\d.]+)(-devel)? ([\\d.]+(-RC[\\d.]+)?)",
+        "url": "https://sourceforge.net/projects/wsjt-x-improved/rss",
+        "regex": "wsjtx-([\\d.]+)(-devel)?-win64_improved_AL_PLUS_([\\d.]+(-RC[\\d.]+)?).exe",
         "replace": "${1}-${3}"
     },
     "autoupdate": {

--- a/bucket/wsjtx-improved-widescreen.json
+++ b/bucket/wsjtx-improved-widescreen.json
@@ -20,8 +20,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/README.txt",
-        "regex": "WSJT-X_IMPROVED ([\\d.]+)(-devel)? ([\\d.]+(-RC[\\d.]+)?)",
+        "url": "https://sourceforge.net/projects/wsjt-x-improved/rss",
+        "regex": "wsjtx-([\\d.]+)(-devel)?-win64_improved_widescreen_PLUS_([\\d.]+(-RC[\\d.]+)?).exe",
         "replace": "${1}-${3}"
     },
     "autoupdate": {

--- a/bucket/wsjtx-improved-widescreen.json
+++ b/bucket/wsjtx-improved-widescreen.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.7.1-250106-RC8",
+    "version": "2.8.0-250314",
     "description": "wsjt-x_improved is an enhanced version (\"the DG2YCB edition\") of the excellent WSJT-X software by Joe Taylor K1JT, Steve Franke K9AN, Bill Somerville G4WJS, me and others (https://sourceforge.net/projects/wsjt/).",
     "homepage": "https://sourceforge.net/projects/wsjt-x-improved/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.7.1/wsjtx-2.7.1-devel-win64_improved_widescreen_PLUS_250106-RC8.exe#/dl.7z",
-            "hash": "sha1:09cebe2137e2f4d18bff4f183ebfa17b39b1aa60"
+            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.8.0/wsjtx-2.8.0-win64_improved_widescreen_PLUS_250314.exe#/dl.7z",
+            "hash": "sha1:718ea80659fa99108bfaafdce42e5c598ece57d8"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.7.1/Windows%2032-bit/wsjtx-2.7.1-devel-win32_improved_widescreen_PLUS_250106-RC8.exe#/dl.7z",
-            "hash": "sha1:bc3bd92db30a501a478a9d2ff391ba27b36c902a"
+            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.8.0/Windows%2032-bit/wsjtx-2.8.0-win32_improved_widescreen_PLUS_250314.exe#/dl.7z",
+            "hash": "sha1:1023adc7c5261a572ed2efdbbd2ebea5d68a9f5c"
         }
     },
     "shortcuts": [

--- a/bucket/wsjtx-improved.json
+++ b/bucket/wsjtx-improved.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.7.1-250106-RC8",
+    "version": "2.8.0-250314",
     "description": "wsjt-x_improved is an enhanced version (\"the DG2YCB edition\") of the excellent WSJT-X software by Joe Taylor K1JT, Steve Franke K9AN, Bill Somerville G4WJS, me and others (https://sourceforge.net/projects/wsjt/).",
     "homepage": "https://sourceforge.net/projects/wsjt-x-improved/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.7.1/wsjtx-2.7.1-devel-win64_improved_PLUS_250106-RC8.exe#/dl.7z",
-            "hash": "sha1:c1de1e075b35c5425d68e3d70ed44befa210ed59"
+            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.8.0/wsjtx-2.8.0-win64_improved_PLUS_250314.exe#/dl.7z",
+            "hash": "sha1:fee2056bc3e4459954afd7f7d889ade27e68e22e"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.7.1/Windows%2032-bit/wsjtx-2.7.1-devel-win32_improved_PLUS_250106-RC8.exe#/dl.7z",
-            "hash": "sha1:bbb99e2243b975e7eda12edd525e57d17a2f4d99"
+            "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/WSJT-X_v2.8.0/Windows%2032-bit/wsjtx-2.8.0-win32_improved_PLUS_250314.exe#/dl.7z",
+            "hash": "sha1:c5862416ef05ce48bd8805a74efd028b77d55cbf"
         }
     },
     "shortcuts": [

--- a/bucket/wsjtx-improved.json
+++ b/bucket/wsjtx-improved.json
@@ -20,8 +20,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://downloads.sourceforge.net/project/wsjt-x-improved/README.txt",
-        "regex": "WSJT-X_IMPROVED ([\\d.]+)(-devel)? ([\\d.]+(-RC[\\d.]+)?)",
+        "url": "https://sourceforge.net/projects/wsjt-x-improved/rss",
+        "regex": "wsjtx-([\\d.]+)(-devel)?-win64_improved_PLUS_([\\d.]+(-RC[\\d.]+)?).exe",
         "replace": "${1}-${3}"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

a change log of `v2.8.0` version doesn't defined in README.

this patch changes information URL to RSS for detecting newer
version.
but this patch has a risk which a script is not able to detect
correct/new version when a project pubish lots built & source files.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
